### PR TITLE
Support Python 3 + usability tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SOFTIOC=/usr/bin/softIoc DUT=$PWD/wrapioc.sh python -m unittest discover catvs.s
 ### Run test against standalone server (e.g in debugger)
 
 ``
-TESTPORT=5064 DUT='sleep 20' python -m unittest catvs.server.test_ops.TestArray.test_monitor_zero_dynamic
+TESTPORT=5064 DUT= python -m unittest catvs.server.test_ops.TestArray.test_monitor_zero_dynamic
 ``
 
 **Then** start the test server within 2 seconds.

--- a/build-deps.sh
+++ b/build-deps.sh
@@ -55,3 +55,6 @@ fi
 echo "EPICS_BASE=$EPICS_BASE" > pcastest/configure/RELEASE.local
 
 echo "EPICS_BASE=$EPICS_BASE" > env
+
+cat env
+cat pcastest/configure/RELEASE.local

--- a/catvs/server/__init__.py
+++ b/catvs/server/__init__.py
@@ -1,3 +1,4 @@
-from test_chan import *
-from test_ops import *
-from test_search import *
+from __future__ import absolute_import
+from .test_chan import *
+from .test_ops import *
+from .test_search import *

--- a/catvs/server/test_chan.py
+++ b/catvs/server/test_chan.py
@@ -4,8 +4,8 @@ import unittest, socket, logging, os
 from ..util import TestClient, Msg
 
 class TestChannel(TestClient, unittest.TestCase):
-    user = 'foo'
-    host = socket.gethostname()
+    user = b'foo'
+    host = socket.gethostname().encode('latin-1')
 
     def openCircuit(self, auth=True):
         'Open TCP connection and sent auth info'
@@ -38,7 +38,7 @@ class TestChannel(TestClient, unittest.TestCase):
         cid, sid = 156, None
 
         self.sendTCP([
-            Msg(cmd=18, p1=cid, p2=13, body='ival'),
+            Msg(cmd=18, p1=cid, p2=13, body=b'ival'),
         ])
 
         rep = self.recvTCP()
@@ -61,7 +61,7 @@ class TestChannel(TestClient, unittest.TestCase):
         cid = 156
 
         self.sendTCP([
-            Msg(cmd=18, p1=cid, p2=13, body='invalid'),
+            Msg(cmd=18, p1=cid, p2=13, body=b'invalid'),
         ])
 
         rep = self.recvTCP()

--- a/catvs/server/test_ops.py
+++ b/catvs/server/test_ops.py
@@ -8,8 +8,8 @@ _log = logging.getLogger(__name__)
 
 class TestScalar(TestClient, unittest.TestCase):
 
-    user = 'foo'
-    host = socket.gethostname()
+    user = b'foo'
+    host = socket.gethostname().encode('latin-1')
 
     def openChan(self):
         'Open TCP connection and create channel'
@@ -19,7 +19,7 @@ class TestScalar(TestClient, unittest.TestCase):
             Msg(cmd=0, dcnt=13),
             Msg(cmd=20, body=self.user),
             Msg(cmd=21, body=self.host),
-            Msg(cmd=18, p1=self.cid, p2=13, body='ival'),
+            Msg(cmd=18, p1=self.cid, p2=13, body=b'ival'),
         ])
 
         rep = self.recvTCP()
@@ -84,7 +84,7 @@ class TestScalar(TestClient, unittest.TestCase):
         self.openChan()
         ioid = 1102
         self.sendTCP([
-            Msg(cmd=4, dtype=5, dcnt=1, p1=self.sid, p2=1101, body='\0\0\0\x2b'),
+            Msg(cmd=4, dtype=5, dcnt=1, p1=self.sid, p2=1101, body=b'\0\0\0\x2b'),
             Msg(cmd=15, dtype=5, dcnt=1, p1=self.sid, p2=ioid),
         ])
 
@@ -97,7 +97,7 @@ class TestScalar(TestClient, unittest.TestCase):
     def test_put_callback(self):
         self.openChan()
         self.sendTCP([
-            Msg(cmd=19, dtype=5, dcnt=1, p1=self.sid, p2=1101, body='\0\0\0\x2c'),
+            Msg(cmd=19, dtype=5, dcnt=1, p1=self.sid, p2=1101, body=b'\0\0\0\x2c'),
         ])
 
         rep = self.recvTCP()
@@ -111,7 +111,7 @@ class TestScalar(TestClient, unittest.TestCase):
         # Note P1 in reply is a CA status code (1==ok)
         self.assertCAEqual(rep, cmd=15, dtype=5, dcnt=1, p1=1, p2=1102)
 
-        self.assertEqual(rep.body[:4], '\0\0\0\x2c')
+        self.assertEqual(rep.body[:4], b'\0\0\0\x2c')
 
     def test_monitor(self):
         self.openChan()
@@ -126,18 +126,18 @@ class TestScalar(TestClient, unittest.TestCase):
         rep = self.recvTCP()
         # Note P1 in reply is a CA status code (1==ok)
         self.assertCAEqual(rep, cmd=1, dtype=5, dcnt=1, p1=1, p2=ioid)
-        self.assertEqual(rep.body[:4], '\0\0\0\x2a')
+        self.assertEqual(rep.body[:4], b'\0\0\0\x2a')
 
         # Send a Put to trigger a subscription update
         self.sendTCP([
-            Msg(cmd=4, dtype=5, dcnt=1, p1=self.sid, p2=1101, body='\0\0\0\x2d'),
+            Msg(cmd=4, dtype=5, dcnt=1, p1=self.sid, p2=1101, body=b'\0\0\0\x2d'),
         ])
 
         # wait for update
         rep = self.recvTCP()
         # Note P1 in reply is a CA status code (1==ok)
         self.assertCAEqual(rep, cmd=1, dtype=5, dcnt=1, p1=1, p2=ioid)
-        self.assertEqual(rep.body[:4], '\0\0\0\x2d')
+        self.assertEqual(rep.body[:4], b'\0\0\0\x2d')
 
         # cancel subscription
         self.sendTCP([
@@ -153,8 +153,8 @@ class TestScalar(TestClient, unittest.TestCase):
 
 class TestArray(TestClient, unittest.TestCase):
 
-    user = 'foo'
-    host = socket.gethostname()
+    user = b'foo'
+    host = socket.gethostname().encode('latin-1')
 
     def openChan(self, cver=13):
         'Open TCP connection and create channel'
@@ -164,7 +164,7 @@ class TestArray(TestClient, unittest.TestCase):
             Msg(cmd=0, dcnt=cver),
             Msg(cmd=20, body=self.user),
             Msg(cmd=21, body=self.host),
-            Msg(cmd=18, p1=self.cid, p2=cver, body='aval'),
+            Msg(cmd=18, p1=self.cid, p2=cver, body=b'aval'),
         ])
 
         rep = self.recvTCP()
@@ -211,9 +211,9 @@ class TestArray(TestClient, unittest.TestCase):
         # RSRV weirdness.
         # first element is undefined when NORD==0
         # should be zero...
-        if rep.body[:2]!='\0\0':
+        if rep.body[:2]!=b'\0\0':
             _log.warn("RSRV weirdness, first element of empty array is undefined")
-        self.assertEqual(rep.body[2:], '\0'*14)
+        self.assertEqual(rep.body[2:], b'\0'*14)
 
     def test_get_some(self):
         self.openChan()
@@ -288,17 +288,17 @@ class TestArray(TestClient, unittest.TestCase):
         ioid = 1102
 
         self.sendTCP([
-            Msg(cmd=4, dtype=1, dcnt=2, p1=self.sid, p2=1101, body='\0\x2b\0\x2c'),
+            Msg(cmd=4, dtype=1, dcnt=2, p1=self.sid, p2=1101, body=b'\0\x2b\0\x2c'),
             Msg(cmd=15, dtype=1, dcnt=5, p1=self.sid, p2=ioid),
             Msg(cmd=15, dtype=1, dcnt=2, p1=self.sid, p2=ioid+1),
         ])
 
         rep = self.recvTCP()
         self.assertCAEqual(rep, cmd=15, dtype=1, dcnt=5, p1=1, p2=ioid)
-        self.assertEqual(rep.body, '\0\x2b\0\x2c\0\0\0\0\0\0\0\0\0\0\0\0')
+        self.assertEqual(rep.body, b'\0\x2b\0\x2c\0\0\0\0\0\0\0\0\0\0\0\0')
         rep = self.recvTCP()
         self.assertCAEqual(rep, cmd=15, dtype=1, dcnt=2, p1=1, p2=ioid+1)
-        self.assertEqual(rep.body, '\0\x2b\0\x2c\0\0\0\0')
+        self.assertEqual(rep.body, b'\0\x2b\0\x2c\0\0\0\0')
 
     def test_monitor_one_fixed(self):
         self.openChan()
@@ -317,32 +317,32 @@ class TestArray(TestClient, unittest.TestCase):
         # RSRV weirdness.
         # first element is undefined when NORD==0
         # should be zero...
-        if rep.body[:2]!='\0\0':
+        if rep.body[:2]!=b'\0\0':
             _log.warn("RSRV weirdness, first element of empty array is undefined")
-        self.assertEqual(rep.body[2:4], '\0\0')
-        # should be self.assertEqual(rep.body[:4], '\0\0\0\0')
+        self.assertEqual(rep.body[2:4], b'\0\0')
+        # should be self.assertEqual(rep.body[:4], b'\0\0\0\0')
 
         # Send Puts to trigger subscription updates
         self.sendTCP([
-            Msg(cmd=4, dtype=5, dcnt=2, p1=self.sid, p2=1101, body='\0\0\0\x2a\0\0\0\x2d'),
+            Msg(cmd=4, dtype=5, dcnt=2, p1=self.sid, p2=1101, body=b'\0\0\0\x2a\0\0\0\x2d'),
         ])
         rep = self.recvTCP()
         self.assertCAEqual(rep, cmd=1, dtype=5, dcnt=1, p1=1, p2=ioid)
-        self.assertEqual(rep.body[:4], '\0\0\0\x2a')
+        self.assertEqual(rep.body[:4], b'\0\0\0\x2a')
 
         self.sendTCP([
-            Msg(cmd=4, dtype=1, dcnt=4, p1=self.sid, p2=1101, body='\0\x2b\0\x2c\0\x2d\0\x2e'),
+            Msg(cmd=4, dtype=1, dcnt=4, p1=self.sid, p2=1101, body=b'\0\x2b\0\x2c\0\x2d\0\x2e'),
         ])
         rep = self.recvTCP()
         self.assertCAEqual(rep, cmd=1, dtype=5, dcnt=1, p1=1, p2=ioid)
-        self.assertEqual(rep.body[:4], '\0\0\0\x2b')
+        self.assertEqual(rep.body[:4], b'\0\0\0\x2b')
 
         self.sendTCP([
-            Msg(cmd=4, dtype=1, dcnt=1, p1=self.sid, p2=1101, body='\0\x2c'),
+            Msg(cmd=4, dtype=1, dcnt=1, p1=self.sid, p2=1101, body=b'\0\x2c'),
         ])
         rep = self.recvTCP()
         self.assertCAEqual(rep, cmd=1, dtype=5, dcnt=1, p1=1, p2=ioid)
-        self.assertEqual(rep.body[:4], '\0\0\0\x2c')
+        self.assertEqual(rep.body[:4], b'\0\0\0\x2c')
 
         # cancel subscription
         self.sendTCP([
@@ -370,32 +370,32 @@ class TestArray(TestClient, unittest.TestCase):
         # RSRV weirdness.
         # first element is undefined when NORD==0
         # should be zero...
-        if rep.body[:2]!='\0\0':
+        if rep.body[:2]!=b'\0\0':
             _log.warn("RSRV weirdness, first element of empty array is undefined")
-        self.assertEqual(rep.body[2:12], '\0'*10)
-        # should be self.assertEqual(rep.body[:12], '\0'*12)
+        self.assertEqual(rep.body[2:12], b'\0'*10)
+        # should be self.assertEqual(rep.body[:12], b'\0'*12)
 
         # Send Puts to trigger subscription updates
         self.sendTCP([
-            Msg(cmd=4, dtype=5, dcnt=2, p1=self.sid, p2=1101, body='\0\0\0\x2a\0\0\0\x2d'),
+            Msg(cmd=4, dtype=5, dcnt=2, p1=self.sid, p2=1101, body=b'\0\0\0\x2a\0\0\0\x2d'),
         ])
         rep = self.recvTCP()
         self.assertCAEqual(rep, cmd=1, dtype=5, dcnt=3, p1=1, p2=ioid)
-        self.assertEqual(rep.body[:12], '\0\0\0\x2a\0\0\0\x2d\0\0\0\0')
+        self.assertEqual(rep.body[:12], b'\0\0\0\x2a\0\0\0\x2d\0\0\0\0')
 
         self.sendTCP([
-            Msg(cmd=4, dtype=1, dcnt=4, p1=self.sid, p2=1101, body='\0\x2b\0\x2c\0\x2d\0\x2e'),
+            Msg(cmd=4, dtype=1, dcnt=4, p1=self.sid, p2=1101, body=b'\0\x2b\0\x2c\0\x2d\0\x2e'),
         ])
         rep = self.recvTCP()
         self.assertCAEqual(rep, cmd=1, dtype=5, dcnt=3, p1=1, p2=ioid)
-        self.assertEqual(rep.body[:12], '\0\0\0\x2b\0\0\0\x2c\0\0\0\x2d')
+        self.assertEqual(rep.body[:12], b'\0\0\0\x2b\0\0\0\x2c\0\0\0\x2d')
 
         self.sendTCP([
-            Msg(cmd=4, dtype=1, dcnt=1, p1=self.sid, p2=1101, body='\0\x2c'),
+            Msg(cmd=4, dtype=1, dcnt=1, p1=self.sid, p2=1101, body=b'\0\x2c'),
         ])
         rep = self.recvTCP()
         self.assertCAEqual(rep, cmd=1, dtype=5, dcnt=3, p1=1, p2=ioid)
-        self.assertEqual(rep.body[:12], '\0\0\0\x2c' + '\0'*8)
+        self.assertEqual(rep.body[:12], b'\0\0\0\x2c' + b'\0'*8)
 
         # cancel subscription
         self.sendTCP([
@@ -423,7 +423,7 @@ class TestArray(TestClient, unittest.TestCase):
 
         # Send a Put to trigger a subscription update
         self.sendTCP([
-            Msg(cmd=4, dtype=5, dcnt=2, p1=self.sid, p2=1101, body='\0\0\0\x2a\0\0\0\x2d'),
+            Msg(cmd=4, dtype=5, dcnt=2, p1=self.sid, p2=1101, body=b'\0\0\0\x2a\0\0\0\x2d'),
         ])
         rep = self.recvTCP()
         # Note P1 in reply is a CA status code (1==ok)
@@ -437,11 +437,11 @@ class TestArray(TestClient, unittest.TestCase):
             pass
         else:
             self.fail("No match %s"%rep)
-        self.assertEqual(rep.body[:8], '\0\0\0\x2a\0\0\0\x2d')
+        self.assertEqual(rep.body[:8], b'\0\0\0\x2a\0\0\0\x2d')
 
         # Send a Put to trigger a subscription update
         self.sendTCP([
-            Msg(cmd=4, dtype=1, dcnt=4, p1=self.sid, p2=1101, body='\0\x2b\0\x2c\0\x2d\0\x2e'),
+            Msg(cmd=4, dtype=1, dcnt=4, p1=self.sid, p2=1101, body=b'\0\x2b\0\x2c\0\x2d\0\x2e'),
         ])
         rep = self.recvTCP()
         # Note P1 in reply is a CA status code (1==ok)
@@ -455,11 +455,11 @@ class TestArray(TestClient, unittest.TestCase):
             pass
         else:
             self.fail("No match %s"%rep)
-        self.assertEqual(rep.body[:16], '\0\0\0\x2b\0\0\0\x2c\0\0\0\x2d\0\0\0\x2e')
+        self.assertEqual(rep.body[:16], b'\0\0\0\x2b\0\0\0\x2c\0\0\0\x2d\0\0\0\x2e')
 
         # Send a Put to trigger a subscription update
         self.sendTCP([
-            Msg(cmd=4, dtype=1, dcnt=1, p1=self.sid, p2=1101, body='\0\x2c'),
+            Msg(cmd=4, dtype=1, dcnt=1, p1=self.sid, p2=1101, body=b'\0\x2c'),
         ])
         rep = self.recvTCP()
         # Note P1 in reply is a CA status code (1==ok)
@@ -473,7 +473,7 @@ class TestArray(TestClient, unittest.TestCase):
             pass
         else:
             self.fail("No match %s"%rep)
-        self.assertEqual(rep.body[:4], '\0\0\0\x2c')
+        self.assertEqual(rep.body[:4], b'\0\0\0\x2c')
 
         # cancel subscription
         self.sendTCP([

--- a/catvs/server/test_ops.py
+++ b/catvs/server/test_ops.py
@@ -303,7 +303,7 @@ class TestArray(TestClient, unittest.TestCase):
         elif rep.p1>>3==22: # PCAS does this
             pass
         else:
-            self.fail("No match %s", rep)
+            self.fail("No match %s" % rep)
         # RSRV returns a body w/ 8 bytes, not sure what this is?
 
     def test_get_zero_dynamic(self):

--- a/catvs/server/test_search.py
+++ b/catvs/server/test_search.py
@@ -20,7 +20,7 @@ class TestSearchUDP(TestClient, unittest.TestCase):
         searchid = 0x12345678
         self.sendUDP([
             Msg(cmd=0, dcnt=13),
-            Msg(cmd=6, body='ival', dtype=5, dcnt=13, p1=searchid, p2=searchid),
+            Msg(cmd=6, body=b'ival', dtype=5, dcnt=13, p1=searchid, p2=searchid),
         ])
 
         rep = self.recvUDP()
@@ -40,7 +40,7 @@ class TestSearchUDP(TestClient, unittest.TestCase):
         searchid = 0x12345678
         self.sendUDP([
             Msg(cmd=0, dcnt=13),
-            Msg(cmd=6, body='invalid', dtype=5, dcnt=13, p1=searchid, p2=searchid),
+            Msg(cmd=6, body=b'invalid', dtype=5, dcnt=13, p1=searchid, p2=searchid),
         ])
 
         self.assertRaises(socket.timeout, self.recvUDP)
@@ -52,7 +52,7 @@ class TestSearchUDP(TestClient, unittest.TestCase):
         searchid = 0x12345678
         self.sendUDP([
             Msg(cmd=0, dcnt=13),
-            Msg(cmd=6, body='invalid', dtype=10, dcnt=13, p1=searchid, p2=searchid),
+            Msg(cmd=6, body=b'invalid', dtype=10, dcnt=13, p1=searchid, p2=searchid),
         ])
 
         self.assertRaises(socket.timeout, self.recvUDP)
@@ -76,7 +76,7 @@ class TestSearchTCP(TestClient, unittest.TestCase):
             self.skipTest("Server doesn't support TCP lookup")
 
         self.sendTCP([
-            Msg(cmd=6, body='ival', dtype=5, dcnt=13, p1=searchid, p2=searchid),
+            Msg(cmd=6, body=b'ival', dtype=5, dcnt=13, p1=searchid, p2=searchid),
         ])
 
         rep = self.recvTCP()
@@ -109,7 +109,7 @@ class TestSearchTCP(TestClient, unittest.TestCase):
             self.skipTest("Server doesn't support TCP lookup")
 
         self.sendTCP([
-            Msg(cmd=6, body='invalid', dtype=5, dcnt=rep.dcnt, p1=searchid, p2=searchid),
+            Msg(cmd=6, body=b'invalid', dtype=5, dcnt=rep.dcnt, p1=searchid, p2=searchid),
         ])
 
         self.assertRaises(socket.timeout, self.recvTCP)
@@ -132,7 +132,7 @@ class TestSearchTCP(TestClient, unittest.TestCase):
             self.skipTest("Server doesn't support TCP lookup")
 
         self.sendTCP([
-            Msg(cmd=6, body='invalid', dtype=10, dcnt=13, p1=searchid, p2=searchid),
+            Msg(cmd=6, body=b'invalid', dtype=10, dcnt=13, p1=searchid, p2=searchid),
         ])
 
         rep = self.recvTCP()
@@ -150,7 +150,7 @@ class TestSearchTCP(TestClient, unittest.TestCase):
         searchid = 0x12345678
         self.sendTCP([
             Msg(cmd=0, dcnt=11),
-            Msg(cmd=6, body='ival', dtype=5, dcnt=11, p1=searchid, p2=searchid),
+            Msg(cmd=6, body=b'ival', dtype=5, dcnt=11, p1=searchid, p2=searchid),
         ])
 
         rep = self.recvTCP()
@@ -161,7 +161,7 @@ class TestSearchTCP(TestClient, unittest.TestCase):
             self.skipTest("Server doesn't support TCP lookup")
 
         self.sendTCP([
-            Msg(cmd=6, body='ival', dtype=5, dcnt=13, p1=searchid, p2=searchid),
+            Msg(cmd=6, body=b'ival', dtype=5, dcnt=13, p1=searchid, p2=searchid),
         ])
 
         rep = self.recvTCP()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from distutils.core import setup
+import setuptools  # noqa F401
+
+
+classifiers = [
+    'Development Status :: 3 - Alpha',
+    'Intended Audience :: Science/Research',
+    'Programming Language :: Python',
+]
+
+
+setup(name='catvs',
+      version='0.0.1',
+      description='EPICS channel access test suite',
+      packages=['catvs', 'catvs.server'],
+      classifiers=classifiers,
+      )

--- a/wrapioc.sh
+++ b/wrapioc.sh
@@ -8,7 +8,7 @@ die() {
 
 [ "$WRAPDEBUG" ] && set -x
 
-[ -x "$SOFTIOC" ] || die "Must set \$SOFTIOC to softIoc executable"
+[ -x "$SOFTIOC" ] || ((env |grep IOC) && die "Must set \$SOFTIOC to softIoc executable")
 
 cat <<EOF > test.db
 record(longout, "ival") {


### PR DESCRIPTION
I made some tweaks to get this going for caproto, which is of course only Python 3.6+.

* Converting all serialization-related stuff to bytes, etc.
* Attempted to keep Python 2 compatibility, but did not test (used print_function, etc.)
* Added basic `setup.py` for package-based installation
* Tweaked initialization making the DUT subprocess optional (use case here: we spawn our server to test, record its port, and then run the test suite)

In the future, you might consider moving this to pytest, as it gives very verbose and useful assertion failed messages. Failures from assertCAEqual (e.g.), in my opinion, are a major pain point of trying to figure out why a specific catvs test failed.